### PR TITLE
feat: create OTP class based on SMTP SSL

### DIFF
--- a/module/data/__init__.py
+++ b/module/data/__init__.py
@@ -3,5 +3,6 @@ from .constants import (
     REPORT,
     HELP,
     HELP_CMD_TEXT,
-    START_CMD_TEXT
+    START_CMD_TEXT,
+    MAIL_TEMPLATE
 )

--- a/module/data/constants.py
+++ b/module/data/constants.py
@@ -6,3 +6,11 @@ HELP_CMD_TEXT = """📬 /report Fornisce la possibilità di poter inviare una se
 
 REPORT = "Segnalazioni Rappresentanti 📬"
 HELP = "Help ❔"
+
+MAIL_TEMPLATE = (
+    "Ciao!\n\n"
+    "Se stai ricevendo questo messaggio vuol dire che ti stai registrando a FinderUniCT-Bot. "
+    "Se non sei stato tu, ignora semplicemente questo messaggio.\n"
+    "Il tuo codice OTP e': {otp}\n\n"
+    "Il team di FinderUniCT-Bot!"
+)

--- a/module/otp.py
+++ b/module/otp.py
@@ -34,13 +34,6 @@ class OTPSender:
 
         Attributes:
             authenticated (bool): True if the user is authenticated, False otherwise.
-
-        Methods:
-            login() -> None: 
-                Logs in to the SMTP server. Modifies the authenticated attribute.
-            send(to: str) -> str | None:
-                Sends a randomly generated OTP to the specified email address.
-                Returns the OTP sent to the specified email address.
     """
     def __init__(self):
         try:
@@ -53,10 +46,11 @@ class OTPSender:
 
     def login(self) -> None:
         """
-            Logs in to the SMTP server.
+            Logs in to the SMTP server. Check the `authenticated` to see if it
+            was successful or not.
 
-            Returns:
-                None: check self.authenticated for login status.
+            Raises:
+                OTPLoginFailed: Something went wrong while trying to contact on the SMTP server.
         """
         if self.authenticated:
             return
@@ -72,10 +66,14 @@ class OTPSender:
             Sends a randomly generated OTP to the specified email address.
 
             Args:
-                to (str): The email address of the recipient.
+                to: The email address of the recipient.
 
             Returns:
-                str: The OTP sent to the specified email address.
+                The OTP sent to the specified email address.
+
+            Raises:
+                OTPNotAuthenticated: You have to be logged in order to send mails.
+                OTPCodeNotSent: Something went wrong while trying to send the mail.
         """
         if not self.authenticated:
             raise OTPNotAuthenticated('Not authenticated.')

--- a/module/otp.py
+++ b/module/otp.py
@@ -1,0 +1,95 @@
+"""
+    OTP module.
+"""
+import os
+import random
+import smtplib
+from email.mime.text import MIMEText
+
+from module.data import MAIL_TEMPLATE
+
+#: Define the following in settings.yaml
+HOST = 'HOST'
+USER = "USER"
+PASSWORD = "PASSWORD"
+
+class OTPException(Exception):
+    pass
+
+class OTPConnectionFailed(OTPException):
+    pass
+
+class OTPLoginFailed(OTPException):
+    pass
+
+class OTPNotAuthenticated(OTPException):
+    pass
+
+class OTPCodeNotSent(OTPException):
+    pass
+
+class OTPSender:
+    """
+        OTP sender class.
+
+        Attributes:
+            authenticated (bool): True if the user is authenticated, False otherwise.
+
+        Methods:
+            login() -> None: 
+                Logs in to the SMTP server. Modifies the authenticated attribute.
+            send(to: str) -> str | None:
+                Sends a randomly generated OTP to the specified email address.
+                Returns the OTP sent to the specified email address.
+    """
+    def __init__(self):
+        try:
+            self.__server = smtplib.SMTP_SSL(HOST, smtplib.SMTP_SSL_PORT)
+        except Exception as e:
+            raise OTPConnectionFailed('Connection failed.') from e
+
+        self.authenticated = False
+        self.login()
+
+    def login(self) -> None:
+        """
+            Logs in to the SMTP server.
+
+            Returns:
+                None: check self.authenticated for login status.
+        """
+        if self.authenticated:
+            return
+
+        try:
+            self.__server.login(USER, PASSWORD)
+            self.authenticated = True
+        except Exception as e:
+            raise OTPLoginFailed('Login failed.') from e
+
+    def send(self, to: str) -> str:
+        """
+            Sends a randomly generated OTP to the specified email address.
+
+            Args:
+                to (str): The email address of the recipient.
+
+            Returns:
+                str: The OTP sent to the specified email address.
+        """
+        if not self.authenticated:
+            raise OTPNotAuthenticated('Not authenticated.')
+
+        random.seed(os.urandom(64))
+        otp = str(random.randint(100000, 999999))
+
+        message = MIMEText(MAIL_TEMPLATE.format(otp=otp))
+        message['From'] = USER
+        message['To'] = to
+        message['Subject'] = "FinderUniCT-Bot - Codice OTP"
+
+        try:
+            self.__server.send_message(message)
+            return otp
+        except Exception as e:
+            raise OTPCodeNotSent('OTP code not sent.') from e


### PR DESCRIPTION
Closes #9 
This class is meant to be used for mail providers that allow login via SMTP (such as libero.it).